### PR TITLE
Listed ALL dependencies for ALL TFM's

### DIFF
--- a/src/nupkg-validator/NuSpecValidator.fs
+++ b/src/nupkg-validator/NuSpecValidator.fs
@@ -40,7 +40,7 @@ type NuSpec(specFile: FileInfo) =
         spec.Document.Root.XPathSelectElements("//x:metadata/x:dependencies/x:group", ns)
         |> Seq.collect (fun e ->
             let tfm = e.Attribute(XName.Get("targetFramework"))
-            let dependencies = e.XPathSelectElements("//x:dependency", ns)
+            let dependencies = e.XPathSelectElements(".//x:dependency", ns)
             dependencies
             |> Seq.map (fun d ->
                 let id = d.Attribute(XName.Get("id"))

--- a/src/nupkg-validator/Program.fs
+++ b/src/nupkg-validator/Program.fs
@@ -52,7 +52,7 @@ let private runSteps (parsed:ParseResults<Arguments>) (tmpFolder:DirectoryInfo) 
             | None -> "*.dll"
         let dlls = tmpFolder.GetFiles(searchFor, SearchOption.AllDirectories) |> Seq.toList
         match dlls  with
-        | [] -> failwithf "No dlls found in %s" tmpFolder.FullName
+        | [] -> failwithf "No dlls found in %s, looking for %s" tmpFolder.FullName searchFor
         | head -> head
       
         


### PR DESCRIPTION
`//` were `.//` was needed as XPath expression