### PR TITLE
Publish as a distroless container and add a major-version release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,21 @@ jobs:
         name: Pack native-AOT tool for ${{ matrix.rid }}
         shell: bash
 
+      # Container image, linux-x64 only for now — the platform every GitHub-hosted Linux runner
+      # already matches. No --push here and no registry login on this leg, so this only proves the
+      # container build itself still works: AOT compiles, the chiseled base image resolves, and the
+      # SDK's container tooling produces an image in the local Docker daemon. The real push to
+      # ghcr.io happens once, in the build job below, which does pass --push.
+      - name: Build container image (no push)
+        if: matrix.rid == 'linux-x64'
+        run: ./build.sh publishcontainers -s true
+        shell: bash
+
+      - name: Report container image size
+        if: matrix.rid == 'linux-x64'
+        shell: bash
+        run: docker images nullean/nupkg-validator --format '{{.Tag}}\t{{.Size}}'
+
       - name: Upload per-RID package
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
@@ -50,6 +65,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: aot-pack
+    permissions:
+      contents: write   # create GitHub release
+      packages: write   # push to GitHub Packages and ghcr.io
+      issues: write     # release-notes creates labels for its categories
     steps:
     - uses: actions/checkout@v5
       with:
@@ -89,6 +108,21 @@ jobs:
       run:  |
         dotnet nuget add source --username USERNAME --password ${{secrets.GITHUB_TOKEN}} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/nullean/index.json"
         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols --source "github"; do echo "Retrying"; sleep 1; done;
+
+    # ghcr.io/nullean/nupkg-validator, matching curb's own tagging: "edge" on every push, plus
+    # "latest" and the semver when this push is an exact release tag — see
+    # publishContainers/containerImageTags in Targets.fs for how that split is decided.
+    - name: Log in to ghcr.io
+      if: github.event_name == 'push'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish container image
+      if: github.event_name == 'push'
+      run: ./build.sh publishcontainers -s true --push
 
     - run: ./build.sh generatereleasenotes -s true
       name: Generate release notes for tag

--- a/.github/workflows/create-major-tag.yml
+++ b/.github/workflows/create-major-tag.yml
@@ -1,0 +1,43 @@
+name: create-major-tag
+
+# Lets a workflow pin this repo as a GitHub Action with `uses: nullean/nupkg-validator@v1` instead of
+# an exact release tag, the same way actions/checkout@v5 stays on v5 across patch and minor releases.
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+concurrency:
+  group: create-major-tag
+  cancel-in-progress: false
+
+jobs:
+  create-major-tag:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: true
+
+      - name: Validate and extract major version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${TAG}' does not match expected semver format (N.N.N)"
+            exit 1
+          fi
+          echo "MAJOR_VERSION=${TAG%%.*}" >> "${GITHUB_ENV}"
+
+      - name: Create major tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag "v${MAJOR_VERSION}"
+          git push -f origin "refs/tags/v${MAJOR_VERSION}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ On Linux, Windows and macOS/arm64, this resolves to a self-contained native-AOT 
 shared .NET runtime required, and no first-run JIT warmup. Everywhere else, it falls back to a
 framework-dependent build (requires the .NET runtime the tool targets to already be installed).
 
+## GitHub Action
+
+```yaml
+- uses: nullean/nupkg-validator@main
+  with:
+    path: build/output/MyPackage.1.0.0.nupkg
+    args: -v 1.0.0 -a MyAssembly -k 96c599bbe3e70f5d
+```
+
+Runs `nupkg-validator` from a pre-built, distroless container (`ghcr.io/nullean/nupkg-validator`) — no
+.NET SDK install needed in the workflow. `path` is the package to validate; extra flags pass through
+verbatim via `args`. Linux runners only (`ubuntu-latest` and similar) — container actions can't run on
+Windows or macOS runners.
+
+## Container image
+
+`ghcr.io/nullean/nupkg-validator` also works as a general-purpose container, outside GitHub Actions —
+GitLab CI, a local machine without the .NET SDK, anywhere `docker run` works:
+
+```sh
+docker run --rm -v "$(pwd)":/workspace ghcr.io/nullean/nupkg-validator:edge validate /workspace/MyPackage.1.0.0.nupkg -v 1.0.0
+```
+
+Distroless: native-AOT, chiseled `runtime-deps` base, no shell, runs as a non-root user. Tags follow
+`nupkg-validator`'s own releases — `edge` tracks the latest commit on `master`, `latest` and a semver
+tag (e.g. `0.10.1`) follow tagged releases.
+
 ## Run
 
 ```bat

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,20 @@
+name: 'nupkg-validator'
+description: 'Validate a NuGet package: dll build configuration, version, and strong-name signing'
+branding:
+  icon: 'check-circle'
+  color: 'blue'
+inputs:
+  path:
+    description: 'Path to the .nupkg file to validate'
+    required: true
+  args:
+    description: 'Extra arguments passed through to nupkg-validator verbatim, e.g. "-v 1.0.0 -a MyAssembly -k <token>"'
+    required: false
+    default: ''
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/nullean/nupkg-validator:edge'
+  args:
+    - validate
+    - ${{ inputs.path }}
+    - ${{ inputs.args }}

--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -15,10 +15,12 @@ type Arguments =
     | [<CliPrefix(CliPrefix.None);SubCommand>] Release
     
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] CreateReleaseOnGithub 
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] PublishContainers
     | [<CliPrefix(CliPrefix.None);SubCommand>] Publish
     
     | [<Inherit;AltCommandLine("-s")>] SingleTarget of bool
     | [<Inherit>] Token of string 
+    | [<Inherit>] Push
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -30,6 +32,7 @@ with
             
             | SingleTarget _ -> "Runs the provided sub command without running their dependencies"
             | Token _ -> "Token to be used to authenticate with github"
+            | Push -> "publishcontainers only: push the built image to ghcr.io instead of building it into the local Docker daemon"
             
             | PristineCheck  
             | GeneratePackages
@@ -37,6 +40,7 @@ with
             | GenerateReleaseNotes
             | GenerateApiChanges
             | CreateReleaseOnGithub 
+            | PublishContainers
                 -> "Undocumented, dependent target"
     member this.Name =
         match FSharpValue.GetUnionFields(this, typeof<Arguments>) with

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -190,6 +190,45 @@ let private createReleaseOnGithub (arguments: ParseResults<Arguments>) =
 
     exec "dotnet" ([ "release-notes" ] @ releaseArgs) |> ignore
 
+/// Tags for the container image, mirroring the versioning currentVersion already derives from git:
+/// "edge" always (so `ghcr.io/nullean/nupkg-validator:edge` is always the latest master build), plus
+/// "latest" and the plain semver when this is an exact release tag rather than a canary commit —
+/// MinVer's canary suffix always contains a hyphen, a clean tag never does.
+let private containerImageTags =
+    lazy (
+        let version = currentVersion.Value
+        if version.Contains("-") then "edge" else sprintf "edge;latest;%s" version
+    )
+
+/// Publishes the CLI's native-AOT build as a container image via the .NET SDK's own container
+/// support (`dotnet publish -t:PublishContainer`), the same mechanism used for curb — see
+/// https://github.com/nullean/curb/pull/72. linux-x64 only for now; a second RID becomes a second
+/// manifest-list platform later with no change to action.yml.
+///
+/// Base image is the chiseled/distroless runtime-deps image: no shell, minimal surface, and correct
+/// for an AOT binary specifically because there is no managed runtime to host — a plain `runtime`
+/// image would carry a CLR this binary never uses.
+///
+/// --push is an explicit flag, not inferred from a CI/event-name environment variable: the aot-pack
+/// job's linux-x64 leg calls this on every trigger (PR, push, tag) purely to prove the container
+/// build itself still works, with no ghcr.io credentials configured there, and an env-based "is this
+/// a push?" check would have tried (and failed) to push from that job on every non-PR trigger. Only
+/// the build job, which does log in, passes --push.
+let private publishContainers (arguments: ParseResults<Arguments>) =
+    let baseImageTag = "10.0-noble-chiseled"
+    let registryArgs =
+        if arguments.Contains Push then [ "-p"; "ContainerRegistry=ghcr.io" ] else []
+    let args =
+        [ "publish"; Paths.RootRelative Paths.ToolProject.FullName; "-c"; "Release"; "-f"; "net10.0"; "-r"; "linux-x64" ]
+        @ [ "/t:PublishContainer"
+            "-p"; "DebugType=none"
+            "-p"; sprintf "ContainerBaseImage=mcr.microsoft.com/dotnet/runtime-deps:%s" baseImageTag
+            "-p"; sprintf "ContainerRepository=%s" Paths.Repository
+            "-p"; sprintf "ContainerImageTags=\"%s\"" containerImageTags.Value
+            "-p"; "ContainerUser=1001:1001" ]
+        @ registryArgs
+    exec "dotnet" args |> ignore
+
 let private release (arguments: ParseResults<Arguments>) = printfn "release"
 
 let private publish (arguments: ParseResults<Arguments>) = printfn "publish"
@@ -230,6 +269,7 @@ let Setup (parsed: ParseResults<Arguments>) (subCommand: Arguments) =
     <| fun _ -> release parsed
 
     step CreateReleaseOnGithub.Name createReleaseOnGithub
+    step PublishContainers.Name publishContainers
 
-    cmd Publish.Name (Some [ Release.Name ]) (Some [ CreateReleaseOnGithub.Name ])
+    cmd Publish.Name (Some [ Release.Name ]) (Some [ CreateReleaseOnGithub.Name; PublishContainers.Name ])
     <| fun _ -> publish parsed

--- a/src/nupkg-validator/nupkg-validator.csproj
+++ b/src/nupkg-validator/nupkg-validator.csproj
@@ -27,6 +27,10 @@
          The root package's DotnetToolSettings.xml (v2) maps each RID to its per-RID package.
          Installing requires the .NET 10 SDK or greater. -->
     <RuntimeIdentifiers>linux-x64;linux-arm64;win-x64;win-arm64;osx-arm64;any</RuntimeIdentifiers>
+    <!-- Lets `dotnet publish -f net10.0 -r <rid> -t:PublishContainer` containerize this same AOT
+         publish output — see build/scripts/Targets.fs's publishContainers target and
+         ghcr.io/nullean/nupkg-validator. -->
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <!-- AOT settings apply only when a specific RID is targeted (dotnet pack -r <rid>). Without this


### PR DESCRIPTION
`nupkg-validator` publishes to `ghcr.io/nullean/nupkg-validator` as a distroless container image with a matching GitHub Action, and each release now also gets a floating major-version git tag.

**Prompt summary:** Add the same ghcr.io container publishing curb already has, wrap it in a GitHub Action that calls the container, and add a floating major-tag workflow so this repo can be pinned as a GitHub Action the way `actions/checkout@v5` is.

## Why

Every consumer of `nupkg-validator` needed the .NET SDK installed to run it, even in CI, where a workflow step just wants to check a package it already built. `curb` solved this for itself in [nullean/curb#72](https://github.com/nullean/curb/pull/72); this repo didn't have the equivalent yet. There was also no way to reference this repo as a GitHub Action pinned to a major version — only exact tags — so a consumer wanting automatic minor/patch updates within a major had nothing to pin to.

## What

#### Container image

`nupkg-validator.csproj` gains `EnableSdkContainerSupport`, and a new `publishContainers` target in `Targets.fs` runs `dotnet publish -t:PublishContainer` against the `linux-x64` AOT build on top of `mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled` — no shell, minimal surface, correct for a binary with no managed runtime to host. Tags follow the same split curb uses: `edge` on every push to `master`, plus `latest` and the plain semver when the push is an exact release tag.

#### CI

The `aot-pack` matrix's `linux-x64` leg now also builds the container image without pushing, purely to prove the build itself still works on every trigger. The `build` job logs in to `ghcr.io` and pushes for real, but only on push events, and only after the managed packages ship to GitHub Packages.

#### GitHub Action

A new `action.yml` at the repo root wraps `docker://ghcr.io/nullean/nupkg-validator:edge`, taking `path` (the package to validate) plus a passthrough `args` for everything else — so a workflow can validate a package with a single `uses:` line and no SDK setup.

#### Major-version tag

A new `create-major-tag.yml` workflow runs on every published release and force-pushes a `vN` tag at that commit, so a workflow can pin `uses: nullean/nupkg-validator@v1` and follow every `1.x.y` release automatically, the same way `actions/checkout@v5` works.

## Verify

```bash
docker run --rm ghcr.io/nullean/nupkg-validator:edge validate --help
```

CI's `aot-pack` (linux-x64) leg proves the container still builds on every PR; the full push to `ghcr.io` only happens on a push to `master` or a release tag.

Made with [Cursor](https://cursor.com)