### PR TITLE
Bump Proc to 0.14.0, fix release-notes CLI invocation and version pin

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -12,7 +12,16 @@ open ProcNet
 let exec binary args =
     Proc.Exec(binary, args |> List.toArray)
 
-let private restoreTools = lazy (exec "dotnet" [ "tool"; "restore" ])
+/// dotnet/sdk#53783: on a cold tool-resolver cache (every fresh CI runner, every fresh container),
+/// restoring 2+ RID-specific tool packages in one manifest can misattribute one package's
+/// DotnetToolSettings.xml to another, failing with "The command ... is not contained in the
+/// package ...". The cache is warm after the first attempt, so a bare retry always succeeds -
+/// see https://github.com/dotnet/sdk/issues/53783.
+let private restoreTools =
+    lazy (
+        try exec "dotnet" [ "tool"; "restore" ]
+        with _ -> exec "dotnet" [ "tool"; "restore" ]
+    )
 
 let private currentVersion =
     lazy(
@@ -144,18 +153,16 @@ let private generateReleaseNotes (arguments: ParseResults<Arguments>) =
         | Some token -> [ "--token"; token ]
 
     let releaseNotesArgs =
-        (Paths.Repository.Split("/") |> Seq.toList)
+        [ "generate" ]
+        @ (Paths.Repository.Split("/") |> Seq.toList)
         @ [ "--version"
             currentVersion
             "--label"
-            "enhancement"
-            "New Features"
+            "enhancement=New Features"
             "--label"
-            "bug"
-            "Bug Fixes"
+            "bug=Bug Fixes"
             "--label"
-            "documentation"
-            "Docs Improvements" ]
+            "documentation=Docs Improvements" ]
         @ tokenArgs
         @ [ "--output"; output ]
 
@@ -178,9 +185,9 @@ let private createReleaseOnGithub (arguments: ParseResults<Arguments>) =
         <| Path.Combine(Paths.Output.FullName, "github-breaking-changes-comments.md")
 
     let releaseArgs =
-        (Paths.Repository.Split("/") |> Seq.toList)
-        @ [ "create-release"
-            "--version"
+        [ "create-release" ]
+        @ (Paths.Repository.Split("/") |> Seq.toList)
+        @ [ "--version"
             currentVersion
             "--body"
             releaseNotes

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.2.5" />
     <PackageReference Include="Bullseye" Version="6.0.0" />
-    <PackageReference Include="Proc" Version="0.9.1" />
+    <PackageReference Include="Proc" Version="0.14.0" />
     <PackageReference Include="Fake.Tools.Git" Version="5.20.3" />
   </ItemGroup>
 

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "release-notes": {
-      "version": "0.6.0",
+      "version": "0.11.0",
       "commands": [
         "release-notes"
       ],


### PR DESCRIPTION
## Summary
- Bumps the `Proc` build-script dependency from 0.9.1 to 0.14.0 (latest), matching the semantics (no shell expansion, throws on failure) already assumed elsewhere.
- `release-notes` was pinned at 0.6.0, a net6.0 build. The `0.11.0` tagged release [failed](https://github.com/nullean/nupkg-validator/actions/runs/33669657668) at the "Generate release notes for tag" step with "You must install or update .NET to run this application." because the CI runner's SDKs start at 8.0. Bumped the pin to 0.11.0 (net8.0+, Argh-based CLI) and fixed `generatereleasenotes`/`createreleaseongithub` to match its new CLI shape (explicit `generate`/`create-release` command, single-token `--label key=value`). Verified against the real 0.11.0 package.
- `dotnet tool restore` now retries once on failure: [dotnet/sdk#53783](https://github.com/dotnet/sdk/issues/53783) causes cold-cache restores of 2+ RID-specific tool packages (all of ours are, now) to misattribute one package's `DotnetToolSettings.xml` to another. A retry always succeeds since the cache is warm afterward.

## Test plan
- [x] `dotnet build build/scripts/scripts.fsproj -c Release` succeeds.
- [x] `./build.sh generatereleasenotes -s true` runs against the real `release-notes` 0.11.0 package and produces correct output.
- [ ] Once merged, cut a `0.11.1` release to complete the release that failed on 0.11.0.

Made with [Cursor](https://cursor.com)