### PR TITLE
Fix generateApiChanges diffing the empty root package instead of .any

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -135,6 +135,11 @@ let private generateApiChanges (arguments: ParseResults<Arguments>) =
           // managed build lives in "nupkg-validator.any" instead.
           sprintf "previous-nuget|%s.any|%s|net8.0" Paths.ToolName currentVersion
           sprintf "directory|src/%s/bin/Release/net10.0" Paths.ToolName
+          // "nupkg-validator.any" doesn't exist on nuget.org yet - the 0.11.0 release that would have
+          // published it failed before reaching the nuget push. Don't fail this first-ever diff
+          // against it; once a version is published this is a no-op.
+          "-a"
+          "true"
           "--target"
           Paths.ToolName
           "-f"

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -129,7 +129,11 @@ let private generateApiChanges (arguments: ParseResults<Arguments>) =
 
     let args =
         [ "assembly-differ"
-          sprintf "previous-nuget|%s|%s|net8.0" Paths.ToolName currentVersion
+          // The plain "nupkg-validator" package id is just a DotnetToolSettings.xml v2 shim pointing
+          // at per-RID sub-packages (see generatePackages above) - it ships no managed assembly of
+          // its own, so NuGetAssemblyProvider would find 0 assemblies there. The portable, signed
+          // managed build lives in "nupkg-validator.any" instead.
+          sprintf "previous-nuget|%s.any|%s|net8.0" Paths.ToolName currentVersion
           sprintf "directory|src/%s/bin/Release/net10.0" Paths.ToolName
           "--target"
           Paths.ToolName


### PR DESCRIPTION
## Summary
This landed on the `fix/proc-version-and-release-notes-cli` branch but that PR (#21) auto-merged before this commit was pushed (its first commit's CI happened to pass, since the previous release it diffed against predated the AOT packaging rewrite). Re-landing it here as its own PR so it's in master before cutting `0.11.1` to complete the failed `0.11.0` release.

The plain `nupkg-validator` package id is a DotnetToolSettings.xml v2 shim that maps RIDs to per-RID sub-packages - it ships no managed assembly of its own, so diffing against it finds 0 assemblies and fails `Inspect public API changes`. Same bug already fixed in `assembly-differ`/`release-notes`/`assembly-rewriter`. Points `previous-nuget` at `nupkg-validator.any` instead.

## Test plan
- [x] `dotnet build build/scripts/scripts.fsproj -c Release` succeeds.

Made with [Cursor](https://cursor.com)