### PR TITLE
Bump release-notes pin to 0.11.1

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "release-notes": {
-      "version": "0.11.0",
+      "version": "0.11.1",
       "commands": [
         "release-notes"
       ],


### PR DESCRIPTION
Fixes the 0.11.1 release failing at "Create or update release for tag on github" — [nullean/release-notes#32](https://github.com/nullean/release-notes/pull/32) fixed Octokit's Native AOT bug where `NewRelease.TagName` (the only mixed-visibility property among its request models) silently vanished from the outgoing JSON under trimming, causing GitHub to reject the request with 422 "tag_name wasn't supplied".

Made with [Cursor](https://cursor.com)