### PR TITLE
Bump release-notes pin to 0.11.2

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "release-notes": {
-      "version": "0.11.1",
+      "version": "0.11.2",
       "commands": [
         "release-notes"
       ],


### PR DESCRIPTION
0.11.1 fixed release creation dropping `tag_name` under Native AOT but missed the identical bug in label creation — [nullean/release-notes#33](https://github.com/nullean/release-notes/pull/33) generalizes the fix to every Octokit write call the tool makes.

Made with [Cursor](https://cursor.com)