### PR TITLE
Bump release-notes pin to 0.11.4

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "release-notes": {
-      "version": "0.11.2",
+      "version": "0.11.4",
       "commands": [
         "release-notes"
       ],


### PR DESCRIPTION
0.11.3 fixed the AOT label-creation bug but release creation's existence check was still unreliable — [nullean/release-notes#34](https://github.com/nullean/release-notes/pull/34) makes it a self-contained idempotent upsert instead, resilient to the concurrent master-push race we hit on 0.11.3.

Made with [Cursor](https://cursor.com)